### PR TITLE
Build datarobot v3.1.0:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,43 +1,45 @@
 {% set name = "datarobot" %}
-{% set version = "3.0.2" %}
+{% set version = "3.1.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1727d6c4b4b502f90655439267e3115cf619ea1ec7bc2e83be3d67b295bef38c
+  sha256: f89dddf377df7d0f9c059c8cd944db996b4990d195c10c59f8e5a19855b80d76
 
 build:
-  noarch: python
+  # typing-extensions 4.3.0 not available for python 3.11
+  skip: true  # [py<3.7 or py==311]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-build-isolation -vvv
 
 requirements:
   host:
-    - python >=3.6,<3.10
+    - python
     - pip
-    - pytest-runner
+    - setuptools
+    - wheel
   run:
-    - python >=3.6,<3.10
+    - python
     - pandas >=0.15
     - pyyaml >=3.11
     - requests >=2.21
     - requests-toolbelt >=0.6
-    - trafaret <2.0,>=0.7,!=1.1.0
+    - trafaret >=0.7,<2.2,!=1.1.0
     - urllib3 >=1.23
-    - attrs >=19.1.0,<20.0
     - contextlib2 >=0.5.5
+    - typing-extensions 4.3.0
     - numpy
-    - python-dateutil
-    - pytz
-    - six
 
 test:
+  requires:
+    - pip
   imports:
     - datarobot
+  commands:
+    - pip check
 
 about:
   home: https://www.datarobot.com/
@@ -48,6 +50,7 @@ about:
   description: |
     datarobot is a client library for working with the <https://www.datarobot.com/> platform API.
   doc_url: https://datarobot-public-api-client.readthedocs-hosted.com
+  dev_url: https://github.com/datarobot
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
 - version increased and sha256 updated.
 - skipping for python 3.11 as there is no typing-extensions support for it.
 - build script updated.
 - host dependencies updated.
 - run dependencies updated.
 - test section updated.
 - dev_url added.